### PR TITLE
Prevent webhook view error when FNAME/LNAME not supplied

### DIFF
--- a/mailchimp/views.py
+++ b/mailchimp/views.py
@@ -143,8 +143,8 @@ class WebHook(MailchimpBaseView):
                     merges[name] = value
             kwargs.update({
                 'email': data['data[email]'],
-                'fname': data['data[merges][FNAME]'],
-                'lname': data['data[merges][LNAME]'],
+                'fname': data['data[merges][FNAME]'] if 'data[merges][FNAME]' in data else '',
+                'lname': data['data[merges][LNAME]'] if 'data[merges][LNAME]' in data else '',
                 'merges': merges,
             })
             if 'data[merges][INTERESTS]' in data:


### PR DESCRIPTION
If FNAME/LNAME are not supplied through merge vars (by being removed at the mailchimp end when setting up a list) the webhook view throws errors

"data[merges][FNAME]' not found in <QueryDict:"

This change sets fname/lname to blank if they're not supplied (but still passes them as signal args, as they're included in Signal providing_args list)
