### PR TITLE
Updated templates to reflect upon changes in Django 1.5

### DIFF
--- a/mailchimp/templates/mailchimp/campaign_information.html
+++ b/mailchimp/templates/mailchimp/campaign_information.html
@@ -1,12 +1,12 @@
 {% extends "admin/change_form.html" %}
-{% load i18n admin_modify adminmedia %}
+{% load i18n admin_modify %}
 
 {% block bodyclass %}change-form{% endblock %}
 
 {% block breadcrumbs %}{% if not is_popup %}
 <div class="breadcrumbs">
-     <a href="{% url admin:index %}">{% trans "Home" %}</a> &rsaquo;
-     <a href="{% url mailchimp_overview %}">{% trans "mailchimp overview" %}</a> &rsaquo;  
+     <a href="{% url 'admin:index' %}">{% trans "Home" %}</a> &rsaquo;
+     <a href="{% url 'mailchimp_overview' %}">{% trans "mailchimp overview" %}</a> &rsaquo;  
      {{ campaign.mc.subject|truncatewords:18 }}
 </div>
 {% endif %}{% endblock %}

--- a/mailchimp/templates/mailchimp/overview.html
+++ b/mailchimp/templates/mailchimp/overview.html
@@ -1,11 +1,11 @@
 {% extends "admin/change_list.html" %}
-{% load i18n admin_modify adminmedia mailchimp_admin_tags %}
+{% load i18n admin_modify mailchimp_admin_tags %}
 
 {% block bodyclass %}change-list{% endblock %}
 
 {% block breadcrumbs %}{% if not is_popup %}
 <div class="breadcrumbs">
-     <a href="{% url admin:index %}">{% trans "Home" %}</a> &rsaquo;
+     <a href="{% url 'admin:index' %}">{% trans "Home" %}</a> &rsaquo;
      {% trans "mailchimp overview" %}
 </div>
 {% endif %}{% endblock %}

--- a/mailchimp/templates/mailchimp/send_button.html
+++ b/mailchimp/templates/mailchimp/send_button.html
@@ -20,7 +20,7 @@
 	{% if is_sent %}
 		{% if sent_date %}
 			{% if can_view %}
-				<a href="{% url mailchimp_campaign_info campaign_id %}">{% trans "Sent via mailchimp:" %}{{ sent_date }}</a>
+				<a href="{% url 'mailchimp_campaign_info campaign_id' %}">{% trans "Sent via mailchimp:" %}{{ sent_date }}</a>
 			{% else %}
 				<span>{% trans "Sent via mailchimp:" %}{{ sent_date }}</span>
 			{% endif %}
@@ -32,7 +32,7 @@
 	</li>
 	<li>
 	{% if can_test %}
-		<a href="{% url mailchimp_test_for_object pk=primary_key content_type=content_type %}">{% trans "Send Test Mail" %}</a>
+		<a href="{% url 'mailchimp_test_for_object pk=primary_key content_type=content_type' %}">{% trans "Send Test Mail" %}</a>
 	{% else %}
 		<span>{% trans "your account requires a valid email to send test mails" %}</span>
 	{% endif %}
@@ -46,7 +46,7 @@ django.jQuery('#send_via_mailchimp').click(
   		var answer = confirm(question);
       	if (answer)
         {
-            window.location = "{% url mailchimp_schedule_for_object pk=primary_key content_type=content_type %}";
+            window.location = "{% url 'mailchimp_schedule_for_object pk=primary_key content_type=content_type' %}";
         }
     }
 )

--- a/mailchimp/templates/mailchimp/send_test.html
+++ b/mailchimp/templates/mailchimp/send_test.html
@@ -1,8 +1,8 @@
 {% extends "admin/change_form.html" %}
-{% load i18n admin_modify adminmedia %}
+{% load i18n admin_modify %}
 
 {% block extrahead %}{{ block.super }}
-<script type="text/javascript" src="{{ MEDIA_URL }}admin/js/jquery.min.js"></script>
+<script type="text/javascript" src="{{ STATIC_URL }}admin/js/jquery.min.js"></script>
 {% endblock %}
 
 {% block bodyclass %}change-form{% endblock %}
@@ -23,7 +23,7 @@ django.jQuery(document).ready(function(){
 	<div class="module aligned campaininfo">
 		<h2>{% trans "Test Sending in Progress" %}</h2>
 		<p style="padding-top:10px;" id="mc-progress-info">{% blocktrans %}Please do not leave the page while the test mail is being sent.
-		This process might take several minutes.{% endblocktrans %} <img src="{{ MEDIA_URL }}img/ajax-loader.gif"></p>
+		This process might take several minutes.{% endblocktrans %} <img src="{{ STATIC_URL }}img/ajax-loader.gif"></p>
 	</div>
 </div>
 {% endblock %}


### PR DESCRIPTION
I've removed/modifed the following calls from the templates, as they have either been significantly altered or depreciated in Django 1.5:

```bash
# Removed because: depreciated
{% load adminmedia %}

# Removed because: depreciated
{{ ADMIN_URL }}
# Replaced with:
{{ STATIC_URL }}

# Removed because: invalid syntax
{% url ARGUMENT %}
# Replaced with:
{% url "ARGUMENT" %}
```

Note: These were only updated as the "Mailchimp Logs" admin panel templates completely fail to load without the above changes.