### PR TITLE
update import for Django 1.6 compatibility

### DIFF
--- a/mailchimp/admin.py
+++ b/mailchimp/admin.py
@@ -5,7 +5,7 @@ from mailchimp.settings import VIEWS_OVERVIEW
 
 class MailchimpAdmin(admin.ModelAdmin):
     def get_urls(self):
-        from django.conf.urls.defaults import patterns, url
+        from django.conf.urls import patterns, url
         urlpatterns = patterns('',
             url(r'^$',
                 VIEWS_OVERVIEW,


### PR DESCRIPTION
django.conf.urls.defaults no longer exists in Django 1.6 . it has been deprecated for a while now
