### PR TITLE
Added the result code to the exception

### DIFF
--- a/mailchimp/chimpy/chimpy.py
+++ b/mailchimp/chimpy/chimpy.py
@@ -58,7 +58,7 @@ class Connection(object):
 
         try:
             if 'error' in result:
-                raise ChimpyException("%s:\n%s" % (result['error'], params))
+                raise ChimpyException("%s:\n%s" % (result['error'], params), result['code'])
         except TypeError:
             # thrown when results is not iterable (eg bool)
             pass


### PR DESCRIPTION
Added the result code the exception so that we can use those codes to create our own error messages, useful for example when using mailchimp on a non-english website.

A list of possible codes that the Mailchimp API can return, is available here: http://apidocs.mailchimp.com/api/1.3/exceptions.field.php
