### PR TITLE
Replaced all references to simplejson

### DIFF
--- a/mailchimp/chimpy/chimpy.py
+++ b/mailchimp/chimpy/chimpy.py
@@ -4,7 +4,7 @@ import pprint
 from utils import transform_datetime
 from utils import flatten
 from warnings import warn
-from django.utils import simplejson
+import json as simplejson
 _debug = 1
 
 

--- a/mailchimp/models.py
+++ b/mailchimp/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils import simplejson
+import json as simplejson
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import generic
 from django.core.urlresolvers import reverse

--- a/mailchimp/models.py
+++ b/mailchimp/models.py
@@ -70,7 +70,7 @@ class Queue(models.Model):
     generate_text = models.BooleanField(default=False)
     auto_tweet = models.BooleanField(default=False)
     segment_options = models.BooleanField(default=False)
-    segment_options_all = models.BooleanField()
+    segment_options_all = models.BooleanField(null=True,default=False)
     segment_options_conditions = models.TextField()
     type_opts = models.TextField()
     content_type = models.ForeignKey(ContentType, null=True, blank=True)

--- a/mailchimp/models.py
+++ b/mailchimp/models.py
@@ -70,7 +70,7 @@ class Queue(models.Model):
     generate_text = models.BooleanField(default=False)
     auto_tweet = models.BooleanField(default=False)
     segment_options = models.BooleanField(default=False)
-    segment_options_all = models.BooleanField(null=True,default=False)
+    segment_options_all = models.NullBooleanField()
     segment_options_conditions = models.TextField()
     type_opts = models.TextField()
     content_type = models.ForeignKey(ContentType, null=True, blank=True)

--- a/mailchimp/utils.py
+++ b/mailchimp/utils.py
@@ -4,7 +4,7 @@ from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.core.cache import cache
 from django.contrib.contenttypes.models import ContentType
-from django.utils import simplejson
+import json as simplejson
 from django.contrib.auth import logout
 from django.contrib.messages import debug, info, success, warning, error, add_message
 from django.http import (


### PR DESCRIPTION
In Django 1.7 the module django.utils.simplejson has been removed in favor of the platform json module. Attempts to use django-mailchimp-v1.3 with Django 1.7 result in an import error. This pull request simply replaces all references to simplejson with a renamed import of the platform json module.