### PR TITLE
models: avoid DeprecationWarning.

### DIFF
--- a/mailchimp/models.py
+++ b/mailchimp/models.py
@@ -1,5 +1,6 @@
+import json
+
 from django.db import models
-from django.utils import simplejson
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import generic
 from django.core.urlresolvers import reverse


### PR DESCRIPTION
Django 1.6: 

```
/home/ubuntu/.virtualenvs/…/local/lib/python2.7/site-packages/mailchimp/models.py:2: DeprecationWarning: django.utils.simplejson is deprecated; use json instead.
```
