### PR TITLE
Moved from django.utils.simplejson to json

### DIFF
--- a/mailchimp/chimp.py
+++ b/mailchimp/chimp.py
@@ -343,7 +343,7 @@ class List(BaseChimpObject):
     def filter_members(self, segment_opts):
         """
         segment_opts = {'match': 'all' if self.segment_options_all else 'any',
-        'conditions': simplejson.loads(self.segment_options_conditions)}
+        'conditions': json.loads(self.segment_options_conditions)}
         """
         mode = all if segment_opts['match'] == 'all' else any
         conditions = [SegmentCondition(**dict((str(k), v) for k,v in c.items())) for c in segment_opts['conditions']]

--- a/mailchimp/chimpy/chimpy.py
+++ b/mailchimp/chimpy/chimpy.py
@@ -1,10 +1,10 @@
 import urllib
 import urllib2
 import pprint
+import json
 from utils import transform_datetime
 from utils import flatten
 from warnings import warn
-from django.utils import simplejson
 _debug = 1
 
 
@@ -54,7 +54,7 @@ class Connection(object):
         if _debug > 1:
             print __name__, "rpc call received", data
 
-        result = simplejson.loads(data)
+        result = json.loads(data)
 
         try:
             if 'error' in result:

--- a/mailchimp/models.py
+++ b/mailchimp/models.py
@@ -1,5 +1,6 @@
+import json
+
 from django.db import models
-from django.utils import simplejson
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import generic
 from django.core.urlresolvers import reverse
@@ -19,10 +20,10 @@ class QueueManager(models.Manager):
         Queue a campaign
         """
         kwargs = locals().copy()
-        kwargs['segment_options_conditions'] = simplejson.dumps(segment_options_conditions)
-        kwargs['type_opts'] = simplejson.dumps(type_opts)
-        kwargs['contents'] = simplejson.dumps(contents)
-        kwargs['extra_info'] = simplejson.dumps(extra_info)
+        kwargs['segment_options_conditions'] = json.dumps(segment_options_conditions)
+        kwargs['type_opts'] = json.dumps(type_opts)
+        kwargs['contents'] = json.dumps(contents)
+        kwargs['extra_info'] = json.dumps(extra_info)
         for thing in ('template_id', 'list_id'):
             thingy = kwargs[thing]
             if hasattr(thingy, 'id'):
@@ -94,7 +95,7 @@ class Queue(models.Model):
         # get connection and send the mails 
         c = get_connection()
         tpl = c.get_template_by_id(self.template_id)
-        content_data = dict([(str(k), v) for k,v in simplejson.loads(self.contents).items()])
+        content_data = dict([(str(k), v) for k,v in json.loads(self.contents).items()])
         built_template = tpl.build(**content_data)
         tracking = {'opens': self.tracking_opens, 
                     'html_clicks': self.tracking_html_clicks,
@@ -104,8 +105,8 @@ class Queue(models.Model):
         else:
             analytics = {}
         segment_opts = {'match': 'all' if self.segment_options_all else 'any',
-            'conditions': simplejson.loads(self.segment_options_conditions)}
-        type_opts = simplejson.loads(self.type_opts)
+            'conditions': json.loads(self.segment_options_conditions)}
+        type_opts = json.loads(self.type_opts)
         title = self.title or self.subject
         camp = c.create_campaign(self.campaign_type, c.get_list_by_id(self.list_id),
             built_template, self.subject, self.from_email, self.from_name,
@@ -119,7 +120,7 @@ class Queue(models.Model):
                 kwargs['content_type'] = self.content_type
                 kwargs['object_id'] = self.object_id
             if self.extra_info:
-                kwargs['extra_info'] = simplejson.loads(self.extra_info)
+                kwargs['extra_info'] = json.loads(self.extra_info)
             return Campaign.objects.create(camp.id, segment_opts, **kwargs)
         # release lock if failed
         self.locked = False
@@ -170,7 +171,7 @@ class CampaignManager(models.Manager):
             extra_info=[]):
         con = get_connection()
         camp = con.get_campaign_by_id(campaign_id)
-        extra_info = simplejson.dumps(extra_info)
+        extra_info = json.dumps(extra_info)
         obj = self.model(content=camp.content, campaign_id=campaign_id,
              name=camp.title, content_type=content_type, object_id=object_id,
              extra_info=extra_info)
@@ -219,7 +220,7 @@ class Campaign(models.Model):
     
     def get_extra_info(self):
         if self.extra_info:
-            return simplejson.loads(self.extra_info)
+            return json.loads(self.extra_info)
         return []
     
     @property

--- a/mailchimp/utils.py
+++ b/mailchimp/utils.py
@@ -4,7 +4,6 @@ from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.core.cache import cache
 from django.contrib.contenttypes.models import ContentType
-from django.utils import simplejson
 from django.contrib.auth import logout
 from django.contrib.messages import debug, info, success, warning, error, add_message
 from django.http import (
@@ -16,6 +15,7 @@ from django.http import (
 from mailchimp.settings import API_KEY, SECURE, REAL_CACHE, CACHE_TIMEOUT
 import re
 import warnings
+import json
 
 class KeywordArguments(dict):
     def __getattr__(self, attr):
@@ -314,7 +314,7 @@ class BaseView(object):
         return HttpResponseServerError(data)
     
     def simplejson(self, data):
-        return HttpResponse(simplejson.dumps(data), content_type='application/json')
+        return HttpResponse(json.dumps(data), content_type='application/json')
     
     def response(self, data):
         return HttpResponse(data)


### PR DESCRIPTION
In Django 1.5, simplejson was deprecated and removed in Django 1.7. They recommend to use built in json module instead. Check
https://docs.djangoproject.com/en/1.7/releases/1.5/#django-utils-simplejson. This change makes this package backwards
incompatible for Python 2.5 and lower since it doesn't have the json module.