### PR TITLE
fixed simplejson imports

### DIFF
--- a/mailchimp/chimp.py
+++ b/mailchimp/chimp.py
@@ -343,7 +343,7 @@ class List(BaseChimpObject):
     def filter_members(self, segment_opts):
         """
         segment_opts = {'match': 'all' if self.segment_options_all else 'any',
-        'conditions': simplejson.loads(self.segment_options_conditions)}
+        'conditions': json.loads(self.segment_options_conditions)}
         """
         mode = all if segment_opts['match'] == 'all' else any
         conditions = [SegmentCondition(**dict((str(k), v) for k,v in c.items())) for c in segment_opts['conditions']]

--- a/mailchimp/chimpy/chimpy.py
+++ b/mailchimp/chimpy/chimpy.py
@@ -1,16 +1,18 @@
+import json
+import pprint
 import urllib
 import urllib2
-import pprint
-import simplejson
-from utils import transform_datetime
-from utils import flatten
 from warnings import warn
+
+from .utils import transform_datetime
+from .utils import flatten
 
 _debug = 1
 
 
 class ChimpyException(Exception):
     pass
+
 
 class ChimpyWarning(Warning):
     pass
@@ -48,14 +50,14 @@ class Connection(object):
             pprint.pprint(params)
             print __name__, "encoded parameters:", params
 
-        response = self.opener.open("%s?method=%s" %(self.url, method), params)
+        response = self.opener.open("%s?method=%s" % (self.url, method), params)
         data = response.read()
         response.close()
 
         if _debug > 1:
             print __name__, "rpc call received", data
 
-        result = simplejson.loads(data)
+        result = json.loads(data)
 
         try:
             iter(result)

--- a/mailchimp/models.py
+++ b/mailchimp/models.py
@@ -1,4 +1,4 @@
-import simplejson
+import json
 
 from django.db import models
 from django.contrib.contenttypes.models import ContentType
@@ -7,8 +7,6 @@ from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext_lazy as _
 from mailchimp.utils import get_connection
-
-import simplejson as json
 
 
 class QueueManager(models.Manager):
@@ -22,10 +20,10 @@ class QueueManager(models.Manager):
         Queue a campaign
         """
         kwargs = locals().copy()
-        kwargs['segment_options_conditions'] = simplejson.dumps(segment_options_conditions)
-        kwargs['type_opts'] = simplejson.dumps(type_opts)
-        kwargs['contents'] = simplejson.dumps(contents)
-        kwargs['extra_info'] = simplejson.dumps(extra_info)
+        kwargs['segment_options_conditions'] = json.dumps(segment_options_conditions)
+        kwargs['type_opts'] = json.dumps(type_opts)
+        kwargs['contents'] = json.dumps(contents)
+        kwargs['extra_info'] = json.dumps(extra_info)
         for thing in ('template_id', 'list_id'):
             thingy = kwargs[thing]
             if hasattr(thingy, 'id'):
@@ -98,7 +96,7 @@ class Queue(models.Model):
         # get connection and send the mails
         c = get_connection()
         tpl = c.get_template_by_id(self.template_id)
-        content_data = dict([(str(k), v) for k,v in simplejson.loads(self.contents).items()])
+        content_data = dict([(str(k), v) for k,v in json.loads(self.contents).items()])
         built_template = tpl.build(**content_data)
         tracking = {'opens': self.tracking_opens,
                     'html_clicks': self.tracking_html_clicks,
@@ -108,8 +106,8 @@ class Queue(models.Model):
         else:
             analytics = {}
         segment_opts = {'match': 'all' if self.segment_options_all else 'any',
-            'conditions': simplejson.loads(self.segment_options_conditions)}
-        type_opts = simplejson.loads(self.type_opts)
+            'conditions': json.loads(self.segment_options_conditions)}
+        type_opts = json.loads(self.type_opts)
         title = self.title or self.subject
         camp = c.create_campaign(self.campaign_type, c.get_list_by_id(self.list_id),
             built_template, self.subject, self.from_email, self.from_name,
@@ -123,7 +121,7 @@ class Queue(models.Model):
                 kwargs['content_type'] = self.content_type
                 kwargs['object_id'] = self.object_id
             if self.extra_info:
-                kwargs['extra_info'] = simplejson.loads(self.extra_info)
+                kwargs['extra_info'] = json.loads(self.extra_info)
             return Campaign.objects.create(camp.id, segment_opts, **kwargs)
         # release lock if failed
         self.locked = False
@@ -174,7 +172,7 @@ class CampaignManager(models.Manager):
             extra_info=[]):
         con = get_connection()
         camp = con.get_campaign_by_id(campaign_id)
-        extra_info = simplejson.dumps(extra_info)
+        extra_info = json.dumps(extra_info)
         obj = self.model(content=camp.content, campaign_id=campaign_id,
              name=camp.title, content_type=content_type, object_id=object_id,
              extra_info=extra_info)
@@ -223,7 +221,7 @@ class Campaign(models.Model):
 
     def get_extra_info(self):
         if self.extra_info:
-            return simplejson.loads(self.extra_info)
+            return json.loads(self.extra_info)
         return []
 
     @property

--- a/mailchimp/utils.py
+++ b/mailchimp/utils.py
@@ -1,4 +1,6 @@
-import simplejson
+import json
+import re
+import warnings
 
 from django.shortcuts import render_to_response
 from django.template import RequestContext
@@ -15,9 +17,6 @@ from django.http import (
     HttpResponseServerError
 )
 from mailchimp.settings import API_KEY, SECURE, REAL_CACHE, CACHE_TIMEOUT
-import re
-import simplejson
-import warnings
 
 class KeywordArguments(dict):
     def __getattr__(self, attr):
@@ -315,8 +314,8 @@ class BaseView(object):
     def server_error(self, data=''):
         return HttpResponseServerError(data)
 
-    def simplejson(self, data):
-        return HttpResponse(simplejson.dumps(data), content_type='application/json')
+    def json(self, data):
+        return HttpResponse(json.dumps(data), content_type='application/json')
 
     def response(self, data):
         return HttpResponse(data)

--- a/mailchimp/views.py
+++ b/mailchimp/views.py
@@ -69,7 +69,7 @@ class TestCampaignForObjectReal(ScheduleCampaignForObject):
                 self.message_warning("%s: %s" % (category.__name__, message))
         else:
             self.message_error("And error has occured while trying to send the test mail to you, please try again later")
-        return self.simplejson(True)
+        return self.json(True)
     
     
 class TestCampaignForObject(ScheduleCampaignForObject):


### PR DESCRIPTION
https://github.com/divio/django-mailchimp/pull/45 replaced `django.utils.simplejson` imports with `simplejson`, but the module is deprecated on python 2.7

This PR replaces `simplejson` imports with the `json` module